### PR TITLE
Add CUSTOM_TEMPLATE_PROCESSOR config

### DIFF
--- a/superset/config.py
+++ b/superset/config.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
         User,
     )
     from superset.models.core import Database  # pylint: disable=unused-import
+    from superset.jinja_context import (  # pylint: disable=unused-import
+        BaseTemplateProcessor,
+    )
 
 # Realtime stats logger, a StatsD implementation exists
 STATS_LOGGER = DummyStatsLogger()
@@ -584,6 +587,59 @@ UPLOADED_CSV_HIVE_NAMESPACE = None
 # meaning values for existing keys get overwritten by the content of this
 # dictionary.
 JINJA_CONTEXT_ADDONS: Dict[str, Callable] = {}
+
+# A dictionary of macro template processors that gets merged into global
+# jinja template processors. The existing template processors get updated with this
+# dictionary, which means the existing keys get overwritten by the content of this
+# dictionary. The customized addons don't necessarily need to use jinjia templating
+# language. This allows you to define custom logic to process macro template.
+#
+# The example below configures a custom presto template processor which implements
+# its own logic of processing macro template with regex parsing. It uses $ style
+# macro instead of Jinja's {{ }} style.
+# By configuring it with CUSTOM_TEMPLATE_PROCESSOR, sql template on presto database
+# is processed by the custom one rather than the default one.
+#
+# def DATE(
+#     ts: datetime, day_offset: SupportsInt = 0, hour_offset: SupportsInt = 0
+# ) -> str:
+#     """Current day as a string"""
+#     day_offset, hour_offset = int(day_offset), int(hour_offset)
+#     offset_day = (ts + timedelta(days=day_offset, hours=hour_offset)).date()
+#     return str(offset_day)
+#
+# class CustomPrestoTemplateProcessor(PrestoTemplateProcessor):
+#     """A custom presto template processor."""
+#
+#     engine = "presto"
+#
+#     def process_template(self, sql: str, **kwargs) -> str:
+#         """Processes a sql template with $ style macro using regex."""
+#         # Add custom macros functions.
+#         macros = {
+#             "DATE": partial(DATE, datetime.utcnow())
+#         }  # type: Dict[str, Any]
+#         # Update with macros defined in context and kwargs.
+#         macros.update(self.context)
+#         macros.update(kwargs)
+#
+#         def replacer(match):
+#             """Expands $ style macros with corresponding function calls."""
+#             macro_name, args_str = match.groups()
+#             args = [a.strip() for a in args_str.split(",")]
+#             if args == [""]:
+#                 args = []
+#             f = macros[macro_name[1:]]
+#             return f(*args)
+#
+#         macro_names = ["$" + name for name in macros.keys()]
+#         pattern = r"(%s)\s*\(([^()]*)\)" % "|".join(map(re.escape, macro_names))
+#         return re.sub(pattern, replacer, sql)
+#
+# CUSTOM_TEMPLATE_PROCESSOR = {
+#     CustomPrestoTemplateProcessor.engine: CustomPrestoTemplateProcessor
+# }
+CUSTOM_TEMPLATE_PROCESSOR = {}  # type: Dict[str, BaseTemplateProcessor]
 
 # Roles that are controlled by the API / Superset and should not be changes
 # by humans.

--- a/superset/jinja_context.py
+++ b/superset/jinja_context.py
@@ -23,6 +23,7 @@ from flask import g, request
 from jinja2.sandbox import SandboxedEnvironment
 
 from superset import jinja_base_context
+from superset.extensions import jinja_context_manager
 
 
 def url_param(param: str, default: Optional[str] = None) -> Optional[Any]:
@@ -263,7 +264,8 @@ class HiveTemplateProcessor(PrestoTemplateProcessor):
     engine = "hive"
 
 
-template_processors = {}
+# The global template processors from Jinja context manager.
+template_processors = jinja_context_manager.template_processors
 keys = tuple(globals().keys())
 for k in keys:
     o = globals()[k]

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -264,6 +264,29 @@ class SupersetTestCase(TestCase):
         )
         if database:
             db.session.delete(database)
+            db.session.commit()
+
+    def create_fake_presto_db(self):
+        self.login(username="admin")
+        database_name = "presto"
+        db_id = 200
+        return self.get_or_create(
+            cls=models.Database,
+            criteria={"database_name": database_name},
+            session=db.session,
+            sqlalchemy_uri="presto://user@host:8080/hive",
+            id=db_id,
+        )
+
+    def delete_fake_presto_db(self):
+        database = (
+            db.session.query(Database)
+            .filter(Database.database_name == "presto")
+            .scalar()
+        )
+        if database:
+            db.session.delete(database)
+            db.session.commit()
 
     def validate_sql(
         self,


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Add CUSTOM_TEMPLATE_PROCESSOR config to allow custom MACRO template processor.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
Manually tested:
1. Plug a customized `DbxPrestoTemplateProcessor` by setting CUSTOM_TEMPLATE_PROCESSOR. The process parses $MACRO.
2. `SELECT '$current_username()'` works.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
