### PR TITLE
Updated Slack file upload call

### DIFF
--- a/superset/tasks/slack_util.py
+++ b/superset/tasks/slack_util.py
@@ -47,7 +47,7 @@ def deliver_slack_msg(
     if file:
         response = cast(
             SlackResponse,
-            client.files_upload(
+            client.files_upload_v2(
                 channels=slack_channel, file=file, initial_comment=body, title=subject
             ),
         )


### PR DESCRIPTION
## Summary
Switch to using the V2 version for file upload API because the original one was deprecated and no longer working.